### PR TITLE
fix spc upload problems

### DIFF
--- a/bugs.md
+++ b/bugs.md
@@ -10,34 +10,22 @@ Generally, at least the following general issues seem at play:
 
 ## List
 
-- Actraiser 2
-  - Freezes after splash-screen (stuck in SPC upload)
 - Air Strike Patrol
   - Bugs due to not emulating mid-scanline effects
-- Battle Grand Prix
-  - Audio freezes after pressing start (SPC stuck in upload loop), game freezes at following SPC upload
 - Death Brade
   - Match ends instantly
 - Firepower 2000
   - Garbage line on title screen background
-- Hiouden - Mamono-tachi to no Chikai
-  - gets stuck on SPC upload on message after after Wolfteam-intro
 - Hook
   - Intros have incorrect colours and glitchy text
 - Mecarobot Golf
   - Some odd flashing of the ground in-game during movement
   - Sometimes freezes (?, hard to reproduce, happened once in lesson mode)
-- Illusion of Gaia
-  - Title screen is silent
-  - Freezes when pressing start (stuck in SPC upload)  
 - Jurassic Park
   - Sides of screen are not masked properly
 - Power Drive
   - Broken graphics on name select screen
   - Cannot control once in-game, only pause
-- Rendering Ranger R2
-  - Freezes on boot (stuck in SPC upload)
-- Soul Blazer
-  - Music sounds slightly off (missing drums on title intro)
 - Tales of Phantasia
-  - Sound effects and music sound off (wrong samples?)
+  - Voices sound fine until music starts playing, then everything gets garbled.
+    (probably unrelated to spc-upload -- investigating.)

--- a/snes/snes.c
+++ b/snes/snes.c
@@ -523,10 +523,13 @@ void snes_cpuIdle(void* mem, bool waiting) {
 
 uint8_t snes_cpuRead(void* mem, uint32_t adr) {
   Snes* snes = (Snes*) mem;
-  int cycles = snes_getAccessTime(snes, adr);
+  int cycles = snes_getAccessTime(snes, adr) - 4;
   dma_handleDma(snes->dma, cycles);
   snes_runCycles(snes, cycles);
-  return snes_read(snes, adr);
+  uint8_t rv = snes_read(snes, adr);
+  dma_handleDma(snes->dma, 4);
+  snes_runCycles(snes, 4);
+  return rv;
 }
 
 void snes_cpuWrite(void* mem, uint32_t adr, uint8_t val) {

--- a/snes/spc.h
+++ b/snes/spc.h
@@ -38,6 +38,15 @@ struct Spc {
   bool stopped;
   // reset
   bool resetWanted;
+  // single-cycle
+  uint8_t opcode;
+  uint32_t step;
+  uint32_t bstep;
+  uint16_t adr;
+  uint16_t adr1;
+  uint8_t dat;
+  uint16_t dat16;
+  uint8_t param;
 };
 
 Spc* spc_init(void* mem, SpcReadHandler read, SpcWriteHandler write, SpcIdleHandler idle);


### PR DESCRIPTION
Hi @angelo-wf,
This pr fixes all of the spc transfer issues that I know of, the theory of why this is necessary is simple:
enix game jams data into the spc as fast as it possibly can, and running a single opcode at a time causes the following problem, example...  snes_catchupApu() needs to run 2 cycles, but the spc runs a whole opcode - of which would be 6 cycles long (0xfe).  The next spc-opcode is a mov from the port.
So, now the next write happens from cpu -> spc, and catching up apu will not run the spc at all since we are in debt by 4 cycles.  Now the spc "misses" the new data, and instead has the old data loaded from the port... uhoh :)

There is a new problem with "Tales of Phantasia".  The samples are no longer corrupted-sounding when they play individually, but when the game starts playing the music and the voice samples at the same time (during the fight) - everything gets garbled.  It sounds like there is a possible overrun in the sample buffer. (this is a guess).  I will investigate this soon,

best regards,
- dink

