### PR TITLE
Fix for Wild Guns

### DIFF
--- a/snes/cpu.h
+++ b/snes/cpu.h
@@ -45,6 +45,7 @@ struct Cpu {
   bool irqWanted;
   bool nmiWanted;
   bool intWanted;
+  bool intDelay;
   bool resetWanted;
 };
 

--- a/snes/dma.c
+++ b/snes/dma.c
@@ -206,6 +206,8 @@ static void dma_waitCycle(Dma* dma) {
 }
 
 static void dma_doDma(Dma* dma, int cpuCycles) {
+  // nmi/irq is delayed by 1 opcode if requested during dma/hdma
+  dma->snes->cpu->intDelay = true;
   // align to multiple of 8
   snes_syncCycles(dma->snes, true, 8);
   // full transfer overhead
@@ -245,6 +247,8 @@ static void dma_initHdma(Dma* dma, bool doSync, int cpuCycles) {
     dma->channel[i].terminated = false;
   }
   if(!hdmaEnabled) return;
+  // nmi/irq is delayed by 1 opcode if requested during dma/hdma
+  dma->snes->cpu->intDelay = true;
   if(doSync) snes_syncCycles(dma->snes, true, 8);
   // full transfer overhead
   snes_runCycles(dma->snes, 8);
@@ -280,6 +284,8 @@ static void dma_doHdma(Dma* dma, bool doSync, int cpuCycles) {
     }
   }
   if(!hdmaActive) return;
+  // nmi/irq is delayed by 1 opcode if requested during dma/hdma
+  dma->snes->cpu->intDelay = true;
   if(doSync) snes_syncCycles(dma->snes, true, 8);
   // full transfer overhead
   snes_runCycles(dma->snes, 8);

--- a/snes/snes.c
+++ b/snes/snes.c
@@ -366,7 +366,8 @@ static void snes_writeReg(Snes* snes, uint16_t adr, uint8_t val) {
       if(!snes->nmiEnabled && (val & 0x80) && snes->inNmi) {
         cpu_nmi(snes->cpu);
       }
-      snes->nmiEnabled = val & 0x80;
+	  snes->nmiEnabled = val & 0x80;
+      snes->cpu->intDelay = true; // nmi/irq is delayed by 1 opcode
       break;
     }
     case 0x4201: {


### PR DESCRIPTION
irq/nmi is delayed by 1 opcode if requested during dma/hdma or writes to 4200.  Fixes Wild Guns